### PR TITLE
Update nav styles to be a little harder to override

### DIFF
--- a/template/public/kss.less
+++ b/template/public/kss.less
@@ -213,6 +213,7 @@ body {
     > .kss-menu-item {
       .base-styles();
       font-size: 14px;
+      display: block;
       > a {
         .clearfix();
         display: block;


### PR DESCRIPTION
Love this template, thanks so much.

I found that adding these two rules prevented any major / strange style overrides.

A basic `<header>` background color or displaying `nav > li` as inline (two things I had in a really basic stylesheet were too easy to override the styleguide template styles. This should help.
