### PR TITLE
updating deprecated template methods

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -30,10 +30,10 @@
             {{else}}
             <ul class="kss-menu-child">
               {{#eachSection rootNumber}}
-              {{#whenDepth 1}}
+              {{#ifDepth 1}}
               {{else}}
               <li class="kss-menu-item"><a href="#section-{{reference}}"><span class="kss-ref">{{reference}}</span><span class="kss-name">{{header}}</span></a></li>
-              {{/whenDepth}}
+              {{/ifDepth}}
               {{/eachSection}}
             </ul>
             {{/if}}
@@ -44,16 +44,16 @@
         <article class="kss-article">
           {{#if overview}}
           <section id="section-0" class="kss-section kss-overview">
-            {{html overview}}
+            {{{overview}}}
           </section>
           {{else}}
           {{#eachSection rootNumber}}
           <section id="section-{{reference}}" class="kss-section kss-depth-{{refDepth}}">
             <h1 class="kss-title"><span class="kss-ref">{{reference}}</span> {{header}}</h1>
-            {{#ifAny markup modifiers}}
+            {{#if markup}}
             {{#if description}}
             <div class="kss-description">
-              {{html description}}
+              {{{description}}}
             </div>
             {{/if}}
             <div class="kss-modifier-block">
@@ -67,7 +67,7 @@
                 <div class="kss-modifier-head">
                   <div class="kss-modifier-name">{{name}}</div>
                   <div class="kss-modifier-description">
-                    {{html description}}
+                    {{{description}}}
                   </div>
                 </div>
                 <div class="kss-modifier-example">
@@ -82,10 +82,10 @@
             {{else}}
             {{#if description}}
             <div class="kss-description">
-              {{html description}}
+              {{{description}}}
             </div>
             {{/if}}
-            {{/ifAny}}
+            {{/if}}
           </section>
           {{/eachSection}}
           {{/if}}


### PR DESCRIPTION
kss-node has been updated since this template was released and a few of the templating methods used have been deprecated, I've updated them so building the styleguide no longer spits out a ton of warnings:

![screen shot 2014-10-29 at 3 44 21 pm](https://cloud.githubusercontent.com/assets/2976552/4835961/2fca0288-5fbd-11e4-9db2-091f5fcf5301.png)
