### PR TITLE
feature(index): allow the use of --js option to join js files to the template

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -101,5 +101,6 @@
     <script src="public/rainbow.min.js"></script>
     <!--<![endif]-->
     <script src="public/main.js"></script>
+    {{{scripts}}}
   </body>
 </html>


### PR DESCRIPTION
This really short PR allows the developers to use the --js option to add javascript files to the template. I.e I need to add Angular libraries to use angular directives inside the documentation.

$> .\node_modules\.bin\kss-node --source src --destination dist --template /vendors/kss-template --homepage readme.md --css public/styleguide.css --js public/js/angular/angular.min.js;